### PR TITLE
Fix HUD refresh and NeoForge Silk Touch XP

### DIFF
--- a/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
+++ b/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
@@ -1,10 +1,7 @@
 package com.iamkaf.liteminer.rendering;
 
 import com.iamkaf.amber.api.functions.v1.WorldFunctions;
-import com.iamkaf.liteminer.Liteminer;
 import com.iamkaf.liteminer.LiteminerClient;
-import com.iamkaf.liteminer.api.shape.LiteminerShape;
-import com.iamkaf.liteminer.shapes.ShapelessWalker;
 import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.ColorTargetState;
@@ -25,12 +22,9 @@ import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3f;
 
@@ -107,14 +101,8 @@ public class BlockHighlightRenderer {
 
     public static InteractionResult renderLiteminerHighlight(Camera camera, SubmitNodeCollector submitNodeCollector, PoseStack poseStack, BlockHitResult blockHitResult, BlockPos blockPos, BlockState blockState) {
         Minecraft mc = Minecraft.getInstance();
-        Level level = mc.level;
-        Player player = mc.player;
-        if (level == null || player == null) {
-            cache.invalidate();
-            return InteractionResult.PASS;
-        }
-
-        if (!LiteminerClient.isVeinMining()) {
+        LiteminerSelection.Snapshot selection = LiteminerSelection.refresh();
+        if (!selection.hasBlocks()) {
             cache.invalidate();
             return InteractionResult.PASS;
         }
@@ -124,47 +112,23 @@ public class BlockHighlightRenderer {
             return InteractionResult.PASS;
         }
 
-        HitResult result = mc.hitResult;
-        if (result == null || result.getType() != HitResult.Type.BLOCK) {
-            cache.invalidate();
-            return InteractionResult.PASS;
-        }
-
-        LiteminerShape shape = LiteminerClient.shapes.getCurrentItem();
-        int currentShapeIndex = LiteminerClient.shapes.getCurrentIndex();
-        int blockLimit = Liteminer.CONFIG.blockBreakLimit.get();
-
-        BlockPos origin = ShapelessWalker.raytraceBlock(level, player);
-
-        HashSet<BlockPos> blocksToHighlight;
         List<Line> linesToRender;
 
-        if (cache.isValid(origin, currentShapeIndex, blockLimit)) {
-            blocksToHighlight = cache.cachedBlocks;
+        if (cache.isValid(selection.origin(), selection.shapeIndex(), selection.blockLimit())) {
             linesToRender = cache.cachedLines;
         } else {
-            blocksToHighlight = shape.walk(level, player, ShapelessWalker.raytrace(level, player).getBlockPos());
-
-            if (blocksToHighlight.isEmpty()) {
-                cache.invalidate();
-                LiteminerClient.selectedBlocks = blocksToHighlight;
-                return InteractionResult.PASS;
-            }
-
-            linesToRender = createHighlightLines(blocksToHighlight, origin);
-            cache.update(origin, currentShapeIndex, blockLimit, blocksToHighlight, linesToRender);
+            linesToRender = createHighlightLines(selection.blocks(), selection.origin());
+            cache.update(selection.origin(), selection.shapeIndex(), selection.blockLimit(), selection.blocks(), linesToRender);
         }
-
-        LiteminerClient.selectedBlocks = blocksToHighlight;
 
         Camera renderInfo = mc.gameRenderer.mainCamera();
         Vec3 projectedView = renderInfo.position();
         assert poseStack != null;
         poseStack.pushPose();
         poseStack.translate(
-                origin.getX() - projectedView.x,
-                origin.getY() - projectedView.y,
-                origin.getZ() - projectedView.z
+                selection.origin().getX() - projectedView.x,
+                selection.origin().getY() - projectedView.y,
+                selection.origin().getZ() - projectedView.z
         );
 
         float lineWidth = mc.getWindow().getAppropriateLineWidth();

--- a/common/src/main/java/com/iamkaf/liteminer/rendering/HUD.java
+++ b/common/src/main/java/com/iamkaf/liteminer/rendering/HUD.java
@@ -28,7 +28,8 @@ public class HUD {
             return;
         }
 
-        int selectedBlockCount = LiteminerClient.selectedBlocks.size();
+        LiteminerSelection.Snapshot selection = LiteminerSelection.refresh();
+        int selectedBlockCount = selection.blocks().size();
 
         if (selectedBlockCount == 0) {
             return;

--- a/common/src/main/java/com/iamkaf/liteminer/rendering/LiteminerSelection.java
+++ b/common/src/main/java/com/iamkaf/liteminer/rendering/LiteminerSelection.java
@@ -1,0 +1,109 @@
+package com.iamkaf.liteminer.rendering;
+
+import com.iamkaf.liteminer.Liteminer;
+import com.iamkaf.liteminer.LiteminerClient;
+import com.iamkaf.liteminer.api.shape.LiteminerShape;
+import com.iamkaf.liteminer.shapes.ShapelessWalker;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.HitResult;
+
+import java.util.HashSet;
+import java.util.Objects;
+
+final class LiteminerSelection {
+    private static final SelectionCache cache = new SelectionCache();
+
+    private LiteminerSelection() {}
+
+    static Snapshot refresh() {
+        Minecraft mc = Minecraft.getInstance();
+        Level level = mc.level;
+        Player player = mc.player;
+        if (level == null || player == null) {
+            return clear();
+        }
+
+        if (!LiteminerClient.isVeinMining()) {
+            return clear();
+        }
+
+        HitResult result = mc.hitResult;
+        if (result == null || result.getType() != HitResult.Type.BLOCK) {
+            return clear();
+        }
+
+        LiteminerShape shape = LiteminerClient.shapes.getCurrentItem();
+        int currentShapeIndex = LiteminerClient.shapes.getCurrentIndex();
+        int blockLimit = Liteminer.CONFIG.blockBreakLimit.get();
+        BlockPos origin = ShapelessWalker.raytraceBlock(level, player);
+
+        HashSet<BlockPos> blocks;
+        if (cache.isValid(origin, currentShapeIndex, blockLimit)) {
+            blocks = cache.cachedBlocks;
+        } else {
+            blocks = shape.walk(level, player, ShapelessWalker.raytrace(level, player).getBlockPos());
+            if (blocks.isEmpty()) {
+                cache.invalidate();
+                return snapshot(origin, currentShapeIndex, blockLimit, blocks);
+            }
+            cache.update(origin, currentShapeIndex, blockLimit, blocks);
+        }
+
+        return snapshot(origin, currentShapeIndex, blockLimit, blocks);
+    }
+
+    private static Snapshot clear() {
+        cache.invalidate();
+        return snapshot(null, -1, 0, new HashSet<>(0));
+    }
+
+    private static Snapshot snapshot(BlockPos origin, int shapeIndex, int blockLimit, HashSet<BlockPos> blocks) {
+        LiteminerClient.selectedBlocks = blocks;
+        return new Snapshot(origin, shapeIndex, blockLimit, blocks);
+    }
+
+    private static long cacheTimeoutMillis(int blockLimit) {
+        return blockLimit >= 512 ? 500L :
+                blockLimit >= 256 ? 300L :
+                blockLimit >= 128 ? 200L :
+                100L;
+    }
+
+    record Snapshot(BlockPos origin, int shapeIndex, int blockLimit, HashSet<BlockPos> blocks) {
+        boolean hasBlocks() {
+            return !blocks.isEmpty();
+        }
+    }
+
+    private static final class SelectionCache {
+        BlockPos lastOrigin;
+        int lastShapeIndex;
+        int lastBlockLimit;
+        HashSet<BlockPos> cachedBlocks;
+        long lastUpdateTime;
+
+        boolean isValid(BlockPos origin, int shapeIndex, int blockLimit) {
+            return cachedBlocks != null &&
+                    Objects.equals(lastOrigin, origin) &&
+                    lastShapeIndex == shapeIndex &&
+                    lastBlockLimit == blockLimit &&
+                    (System.currentTimeMillis() - lastUpdateTime) < cacheTimeoutMillis(blockLimit);
+        }
+
+        void update(BlockPos origin, int shapeIndex, int blockLimit, HashSet<BlockPos> blocks) {
+            this.lastOrigin = origin;
+            this.lastShapeIndex = shapeIndex;
+            this.lastBlockLimit = blockLimit;
+            this.cachedBlocks = blocks;
+            this.lastUpdateTime = System.currentTimeMillis();
+        }
+
+        void invalidate() {
+            this.lastOrigin = null;
+            this.cachedBlocks = null;
+        }
+    }
+}

--- a/versions/1.21.11/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
+++ b/versions/1.21.11/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
@@ -1,10 +1,7 @@
 package com.iamkaf.liteminer.rendering;
 
 import com.iamkaf.amber.api.functions.v1.WorldFunctions;
-import com.iamkaf.liteminer.Liteminer;
 import com.iamkaf.liteminer.LiteminerClient;
-import com.iamkaf.liteminer.api.shape.LiteminerShape;
-import com.iamkaf.liteminer.shapes.ShapelessWalker;
 import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.platform.DepthTestFunction;
@@ -21,12 +18,9 @@ import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3f;
 
@@ -101,14 +95,8 @@ public class BlockHighlightRenderer {
 
     public static InteractionResult renderLiteminerHighlight(Camera camera, MultiBufferSource multiBufferSource, PoseStack poseStack, BlockHitResult blockHitResult, BlockPos blockPos, BlockState blockState) {
         Minecraft mc = Minecraft.getInstance();
-        Level level = mc.level;
-        Player player = mc.player;
-        if (level == null || player == null) {
-            cache.invalidate();
-            return InteractionResult.PASS;
-        }
-
-        if (!LiteminerClient.isVeinMining()) {
+        LiteminerSelection.Snapshot selection = LiteminerSelection.refresh();
+        if (!selection.hasBlocks()) {
             cache.invalidate();
             return InteractionResult.PASS;
         }
@@ -118,46 +106,23 @@ public class BlockHighlightRenderer {
             return InteractionResult.PASS;
         }
 
-        HitResult result = mc.hitResult;
-        if (result == null || result.getType() != HitResult.Type.BLOCK) {
-            cache.invalidate();
-            return InteractionResult.PASS;
-        }
-
-        LiteminerShape shape = LiteminerClient.shapes.getCurrentItem();
-        int currentShapeIndex = LiteminerClient.shapes.getCurrentIndex();
-        int blockLimit = Liteminer.CONFIG.blockBreakLimit.get();
-        BlockPos origin = ShapelessWalker.raytraceBlock(level, player);
-
-        HashSet<BlockPos> blocksToHighlight;
         List<Line> linesToRender;
 
-        if (cache.isValid(origin, currentShapeIndex, blockLimit)) {
-            blocksToHighlight = cache.cachedBlocks;
+        if (cache.isValid(selection.origin(), selection.shapeIndex(), selection.blockLimit())) {
             linesToRender = cache.cachedLines;
         } else {
-            blocksToHighlight = shape.walk(level, player, ShapelessWalker.raytrace(level, player).getBlockPos());
-
-            if (blocksToHighlight.isEmpty()) {
-                cache.invalidate();
-                LiteminerClient.selectedBlocks = blocksToHighlight;
-                return InteractionResult.PASS;
-            }
-
-            linesToRender = createHighlightLines(blocksToHighlight, origin);
-            cache.update(origin, currentShapeIndex, blockLimit, blocksToHighlight, linesToRender);
+            linesToRender = createHighlightLines(selection.blocks(), selection.origin());
+            cache.update(selection.origin(), selection.shapeIndex(), selection.blockLimit(), selection.blocks(), linesToRender);
         }
-
-        LiteminerClient.selectedBlocks = blocksToHighlight;
 
         Camera renderInfo = mc.gameRenderer.getMainCamera();
         Vec3 projectedView = renderInfo.position();
         assert poseStack != null;
         poseStack.pushPose();
         poseStack.translate(
-                origin.getX() - projectedView.x,
-                origin.getY() - projectedView.y,
-                origin.getZ() - projectedView.z
+                selection.origin().getX() - projectedView.x,
+                selection.origin().getY() - projectedView.y,
+                selection.origin().getZ() - projectedView.z
         );
 
         MultiBufferSource.BufferSource buffers = mc.renderBuffers().bufferSource();

--- a/versions/1.21.11/common/src/main/java/com/iamkaf/liteminer/rendering/HUD.java
+++ b/versions/1.21.11/common/src/main/java/com/iamkaf/liteminer/rendering/HUD.java
@@ -28,7 +28,8 @@ public class HUD {
             return;
         }
 
-        int selectedBlockCount = LiteminerClient.selectedBlocks.size();
+        LiteminerSelection.Snapshot selection = LiteminerSelection.refresh();
+        int selectedBlockCount = selection.blocks().size();
 
         if (selectedBlockCount == 0) {
             return;

--- a/versions/26.1.1/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
+++ b/versions/26.1.1/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
@@ -1,10 +1,7 @@
 package com.iamkaf.liteminer.rendering;
 
 import com.iamkaf.amber.api.functions.v1.WorldFunctions;
-import com.iamkaf.liteminer.Liteminer;
 import com.iamkaf.liteminer.LiteminerClient;
-import com.iamkaf.liteminer.api.shape.LiteminerShape;
-import com.iamkaf.liteminer.shapes.ShapelessWalker;
 import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.ColorTargetState;
 import com.mojang.blaze3d.pipeline.DepthStencilState;
@@ -25,12 +22,9 @@ import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3f;
 
@@ -106,14 +100,8 @@ public class BlockHighlightRenderer {
 
     public static InteractionResult renderLiteminerHighlight(Camera camera, MultiBufferSource multiBufferSource, PoseStack poseStack, BlockHitResult blockHitResult, BlockPos blockPos, BlockState blockState) {
         Minecraft mc = Minecraft.getInstance();
-        Level level = mc.level;
-        Player player = mc.player;
-        if (level == null || player == null) {
-            cache.invalidate();
-            return InteractionResult.PASS;
-        }
-
-        if (!LiteminerClient.isVeinMining()) {
+        LiteminerSelection.Snapshot selection = LiteminerSelection.refresh();
+        if (!selection.hasBlocks()) {
             cache.invalidate();
             return InteractionResult.PASS;
         }
@@ -123,46 +111,23 @@ public class BlockHighlightRenderer {
             return InteractionResult.PASS;
         }
 
-        HitResult result = mc.hitResult;
-        if (result == null || result.getType() != HitResult.Type.BLOCK) {
-            cache.invalidate();
-            return InteractionResult.PASS;
-        }
-
-        LiteminerShape shape = LiteminerClient.shapes.getCurrentItem();
-        int currentShapeIndex = LiteminerClient.shapes.getCurrentIndex();
-        int blockLimit = Liteminer.CONFIG.blockBreakLimit.get();
-        BlockPos origin = ShapelessWalker.raytraceBlock(level, player);
-
-        HashSet<BlockPos> blocksToHighlight;
         List<Line> linesToRender;
 
-        if (cache.isValid(origin, currentShapeIndex, blockLimit)) {
-            blocksToHighlight = cache.cachedBlocks;
+        if (cache.isValid(selection.origin(), selection.shapeIndex(), selection.blockLimit())) {
             linesToRender = cache.cachedLines;
         } else {
-            blocksToHighlight = shape.walk(level, player, ShapelessWalker.raytrace(level, player).getBlockPos());
-
-            if (blocksToHighlight.isEmpty()) {
-                cache.invalidate();
-                LiteminerClient.selectedBlocks = blocksToHighlight;
-                return InteractionResult.PASS;
-            }
-
-            linesToRender = createHighlightLines(blocksToHighlight, origin);
-            cache.update(origin, currentShapeIndex, blockLimit, blocksToHighlight, linesToRender);
+            linesToRender = createHighlightLines(selection.blocks(), selection.origin());
+            cache.update(selection.origin(), selection.shapeIndex(), selection.blockLimit(), selection.blocks(), linesToRender);
         }
-
-        LiteminerClient.selectedBlocks = blocksToHighlight;
 
         Camera renderInfo = mc.gameRenderer.getMainCamera();
         Vec3 projectedView = renderInfo.position();
         assert poseStack != null;
         poseStack.pushPose();
         poseStack.translate(
-                origin.getX() - projectedView.x,
-                origin.getY() - projectedView.y,
-                origin.getZ() - projectedView.z
+                selection.origin().getX() - projectedView.x,
+                selection.origin().getY() - projectedView.y,
+                selection.origin().getZ() - projectedView.z
         );
 
         MultiBufferSource.BufferSource buffers = mc.renderBuffers().bufferSource();

--- a/versions/26.1.1/common/src/main/java/com/iamkaf/liteminer/rendering/HUD.java
+++ b/versions/26.1.1/common/src/main/java/com/iamkaf/liteminer/rendering/HUD.java
@@ -28,7 +28,8 @@ public class HUD {
             return;
         }
 
-        int selectedBlockCount = LiteminerClient.selectedBlocks.size();
+        LiteminerSelection.Snapshot selection = LiteminerSelection.refresh();
+        int selectedBlockCount = selection.blocks().size();
 
         if (selectedBlockCount == 0) {
             return;

--- a/versions/26.1.2/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
+++ b/versions/26.1.2/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
@@ -1,10 +1,7 @@
 package com.iamkaf.liteminer.rendering;
 
 import com.iamkaf.amber.api.functions.v1.WorldFunctions;
-import com.iamkaf.liteminer.Liteminer;
 import com.iamkaf.liteminer.LiteminerClient;
-import com.iamkaf.liteminer.api.shape.LiteminerShape;
-import com.iamkaf.liteminer.shapes.ShapelessWalker;
 import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.ColorTargetState;
 import com.mojang.blaze3d.pipeline.DepthStencilState;
@@ -25,12 +22,9 @@ import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3f;
 
@@ -106,14 +100,8 @@ public class BlockHighlightRenderer {
 
     public static InteractionResult renderLiteminerHighlight(Camera camera, MultiBufferSource multiBufferSource, PoseStack poseStack, BlockHitResult blockHitResult, BlockPos blockPos, BlockState blockState) {
         Minecraft mc = Minecraft.getInstance();
-        Level level = mc.level;
-        Player player = mc.player;
-        if (level == null || player == null) {
-            cache.invalidate();
-            return InteractionResult.PASS;
-        }
-
-        if (!LiteminerClient.isVeinMining()) {
+        LiteminerSelection.Snapshot selection = LiteminerSelection.refresh();
+        if (!selection.hasBlocks()) {
             cache.invalidate();
             return InteractionResult.PASS;
         }
@@ -123,46 +111,23 @@ public class BlockHighlightRenderer {
             return InteractionResult.PASS;
         }
 
-        HitResult result = mc.hitResult;
-        if (result == null || result.getType() != HitResult.Type.BLOCK) {
-            cache.invalidate();
-            return InteractionResult.PASS;
-        }
-
-        LiteminerShape shape = LiteminerClient.shapes.getCurrentItem();
-        int currentShapeIndex = LiteminerClient.shapes.getCurrentIndex();
-        int blockLimit = Liteminer.CONFIG.blockBreakLimit.get();
-        BlockPos origin = ShapelessWalker.raytraceBlock(level, player);
-
-        HashSet<BlockPos> blocksToHighlight;
         List<Line> linesToRender;
 
-        if (cache.isValid(origin, currentShapeIndex, blockLimit)) {
-            blocksToHighlight = cache.cachedBlocks;
+        if (cache.isValid(selection.origin(), selection.shapeIndex(), selection.blockLimit())) {
             linesToRender = cache.cachedLines;
         } else {
-            blocksToHighlight = shape.walk(level, player, ShapelessWalker.raytrace(level, player).getBlockPos());
-
-            if (blocksToHighlight.isEmpty()) {
-                cache.invalidate();
-                LiteminerClient.selectedBlocks = blocksToHighlight;
-                return InteractionResult.PASS;
-            }
-
-            linesToRender = createHighlightLines(blocksToHighlight, origin);
-            cache.update(origin, currentShapeIndex, blockLimit, blocksToHighlight, linesToRender);
+            linesToRender = createHighlightLines(selection.blocks(), selection.origin());
+            cache.update(selection.origin(), selection.shapeIndex(), selection.blockLimit(), selection.blocks(), linesToRender);
         }
-
-        LiteminerClient.selectedBlocks = blocksToHighlight;
 
         Camera renderInfo = mc.gameRenderer.getMainCamera();
         Vec3 projectedView = renderInfo.position();
         assert poseStack != null;
         poseStack.pushPose();
         poseStack.translate(
-                origin.getX() - projectedView.x,
-                origin.getY() - projectedView.y,
-                origin.getZ() - projectedView.z
+                selection.origin().getX() - projectedView.x,
+                selection.origin().getY() - projectedView.y,
+                selection.origin().getZ() - projectedView.z
         );
 
         MultiBufferSource.BufferSource buffers = mc.renderBuffers().bufferSource();

--- a/versions/26.1.2/common/src/main/java/com/iamkaf/liteminer/rendering/HUD.java
+++ b/versions/26.1.2/common/src/main/java/com/iamkaf/liteminer/rendering/HUD.java
@@ -28,7 +28,8 @@ public class HUD {
             return;
         }
 
-        int selectedBlockCount = LiteminerClient.selectedBlocks.size();
+        LiteminerSelection.Snapshot selection = LiteminerSelection.refresh();
+        int selectedBlockCount = selection.blocks().size();
 
         if (selectedBlockCount == 0) {
             return;

--- a/versions/26.1/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
+++ b/versions/26.1/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
@@ -1,10 +1,7 @@
 package com.iamkaf.liteminer.rendering;
 
 import com.iamkaf.amber.api.functions.v1.WorldFunctions;
-import com.iamkaf.liteminer.Liteminer;
 import com.iamkaf.liteminer.LiteminerClient;
-import com.iamkaf.liteminer.api.shape.LiteminerShape;
-import com.iamkaf.liteminer.shapes.ShapelessWalker;
 import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.ColorTargetState;
 import com.mojang.blaze3d.pipeline.DepthStencilState;
@@ -25,12 +22,9 @@ import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3f;
 
@@ -106,14 +100,8 @@ public class BlockHighlightRenderer {
 
     public static InteractionResult renderLiteminerHighlight(Camera camera, MultiBufferSource multiBufferSource, PoseStack poseStack, BlockHitResult blockHitResult, BlockPos blockPos, BlockState blockState) {
         Minecraft mc = Minecraft.getInstance();
-        Level level = mc.level;
-        Player player = mc.player;
-        if (level == null || player == null) {
-            cache.invalidate();
-            return InteractionResult.PASS;
-        }
-
-        if (!LiteminerClient.isVeinMining()) {
+        LiteminerSelection.Snapshot selection = LiteminerSelection.refresh();
+        if (!selection.hasBlocks()) {
             cache.invalidate();
             return InteractionResult.PASS;
         }
@@ -123,46 +111,23 @@ public class BlockHighlightRenderer {
             return InteractionResult.PASS;
         }
 
-        HitResult result = mc.hitResult;
-        if (result == null || result.getType() != HitResult.Type.BLOCK) {
-            cache.invalidate();
-            return InteractionResult.PASS;
-        }
-
-        LiteminerShape shape = LiteminerClient.shapes.getCurrentItem();
-        int currentShapeIndex = LiteminerClient.shapes.getCurrentIndex();
-        int blockLimit = Liteminer.CONFIG.blockBreakLimit.get();
-        BlockPos origin = ShapelessWalker.raytraceBlock(level, player);
-
-        HashSet<BlockPos> blocksToHighlight;
         List<Line> linesToRender;
 
-        if (cache.isValid(origin, currentShapeIndex, blockLimit)) {
-            blocksToHighlight = cache.cachedBlocks;
+        if (cache.isValid(selection.origin(), selection.shapeIndex(), selection.blockLimit())) {
             linesToRender = cache.cachedLines;
         } else {
-            blocksToHighlight = shape.walk(level, player, ShapelessWalker.raytrace(level, player).getBlockPos());
-
-            if (blocksToHighlight.isEmpty()) {
-                cache.invalidate();
-                LiteminerClient.selectedBlocks = blocksToHighlight;
-                return InteractionResult.PASS;
-            }
-
-            linesToRender = createHighlightLines(blocksToHighlight, origin);
-            cache.update(origin, currentShapeIndex, blockLimit, blocksToHighlight, linesToRender);
+            linesToRender = createHighlightLines(selection.blocks(), selection.origin());
+            cache.update(selection.origin(), selection.shapeIndex(), selection.blockLimit(), selection.blocks(), linesToRender);
         }
-
-        LiteminerClient.selectedBlocks = blocksToHighlight;
 
         Camera renderInfo = mc.gameRenderer.getMainCamera();
         Vec3 projectedView = renderInfo.position();
         assert poseStack != null;
         poseStack.pushPose();
         poseStack.translate(
-                origin.getX() - projectedView.x,
-                origin.getY() - projectedView.y,
-                origin.getZ() - projectedView.z
+                selection.origin().getX() - projectedView.x,
+                selection.origin().getY() - projectedView.y,
+                selection.origin().getZ() - projectedView.z
         );
 
         MultiBufferSource.BufferSource buffers = mc.renderBuffers().bufferSource();

--- a/versions/26.1/common/src/main/java/com/iamkaf/liteminer/rendering/HUD.java
+++ b/versions/26.1/common/src/main/java/com/iamkaf/liteminer/rendering/HUD.java
@@ -28,7 +28,8 @@ public class HUD {
             return;
         }
 
-        int selectedBlockCount = LiteminerClient.selectedBlocks.size();
+        LiteminerSelection.Snapshot selection = LiteminerSelection.refresh();
+        int selectedBlockCount = selection.blocks().size();
 
         if (selectedBlockCount == 0) {
             return;


### PR DESCRIPTION
Fixes two player-visible Liteminer bugs.

The HUD now refreshes its active selection independently from block highlight rendering, so disabling highlights no longer makes the block count and shape text disappear or go stale.

NeoForge secondary-block XP now goes through vanilla enchantment block-XP processing after NeoForge computes the raw block XP. This keeps normal NeoForge XP drops working while letting Silk Touch suppress XP from secondary ore blocks.

This covers the Forge Config API Port-backed lines (`1.21.11`, `26.1`, `26.1.1`, `26.1.2`) and the current Konfig-backed line (`26.2`) through the shared Stonecutter source roots.

Fixes #62.
Fixes iamkaf/mod-issues#77.

Compiled NeoForge for `1.21.11`, `26.1`, `26.1.1`, `26.1.2`, and `26.2`.