### PR TITLE
Fix see-through highlights with Iris shaders

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,12 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Block highlight lines now render correctly when Iris shaders are enabled.
+- Require Correct Tool no longer blocks vein mining for blocks that can be harvested without a tool.
+- Vein-mined item drops no longer spawn inside adjacent blocks and rise toward the surface.
 
 ## 3.1.4
 
 ### Fixed
 
 - Block highlight lines now render correctly when Iris shaders are enabled.
+- Require Correct Tool no longer blocks vein mining for blocks that can be harvested without a tool.
+- Vein-mined item drops no longer spawn inside adjacent blocks and rise toward the surface.
 
 ## 4.1.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.1.3
+
+### Fixed
+
+- Block highlight lines now render correctly when Iris shaders are enabled.
+
+## 3.1.4
+
+### Fixed
+
+- Block highlight lines now render correctly when Iris shaders are enabled.
+
 ## 4.1.2
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Block Break Limit slider can now be adjusted one block at a time with the arrow keys and reset to 64 with right-click.
 - Block highlight lines now render correctly when Iris shaders are enabled.
 - Require Correct Tool no longer blocks vein mining for blocks that can be harvested without a tool.
 - Vein-mined item drops no longer spawn inside adjacent blocks and rise toward the surface.
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Block Break Limit slider can now be adjusted one block at a time with the arrow keys and reset to 64 with right-click.
 - Block highlight lines now render correctly when Iris shaders are enabled.
 - Require Correct Tool no longer blocks vein mining for blocks that can be harvested without a tool.
 - Vein-mined item drops no longer spawn inside adjacent blocks and rise toward the surface.

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -9,6 +9,10 @@ val minecraftVersion = multiloader.minecraftVersion()
 val catalog = multiloader.catalogFor()
 
 dependencies {
+    compileOnly("maven.modrinth:iris:${multiloader.requiredProperty("dependencies.iris")}") {
+        isTransitive = false
+    }
+
     if (minecraftVersion != "26.2") {
         add("implementation", multiloader.library(catalog, "forgeconfigapiport-common-neoforgeapi"))
     }

--- a/common/src/main/java/com/iamkaf/liteminer/compat/IrisCompat.java
+++ b/common/src/main/java/com/iamkaf/liteminer/compat/IrisCompat.java
@@ -1,0 +1,32 @@
+package com.iamkaf.liteminer.compat;
+
+import com.iamkaf.amber.api.platform.v1.Platform;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import net.irisshaders.iris.api.v0.IrisApi;
+import net.irisshaders.iris.api.v0.IrisProgram;
+
+/**
+ * Optional Iris integration for Liteminer's custom world-rendering pipelines.
+ */
+public final class IrisCompat {
+    private IrisCompat() {
+    }
+
+    public static void assignLinesPipeline(RenderPipeline pipeline) {
+        if (Platform.isModLoaded("iris")) {
+            IrisBridge.assignLinesPipeline(pipeline);
+        }
+    }
+
+    /**
+     * Kept behind a nested class so Iris API types are never resolved when Iris is absent.
+     */
+    private static final class IrisBridge {
+        private IrisBridge() {
+        }
+
+        private static void assignLinesPipeline(RenderPipeline pipeline) {
+            IrisApi.getInstance().assignPipeline(pipeline, IrisProgram.LINES);
+        }
+    }
+}

--- a/common/src/main/java/com/iamkaf/liteminer/event/OnBlockBreak.java
+++ b/common/src/main/java/com/iamkaf/liteminer/event/OnBlockBreak.java
@@ -17,11 +17,11 @@ import net.minecraft.tags.EnchantmentTags;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.ExperienceOrb;
-import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.IceBlock;
 import net.minecraft.world.attribute.EnvironmentAttributes;
@@ -182,17 +182,7 @@ public class OnBlockBreak {
                 }
 
                 for (var stack : state.getDrops(builder)) {
-                    var itemEntity = new ItemEntity(
-                            level,
-                            absoluteOrigin.getX(),
-                            absoluteOrigin.getY(),
-                            absoluteOrigin.getZ(),
-                            stack,
-                            level.getRandom().nextFloat() / 10,
-                            0.25f,
-                            level.getRandom().nextFloat() / 10
-                    );
-                    level.addFreshEntity(itemEntity);
+                    Block.popResource(level, block, stack);
                 }
             }
 

--- a/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
+++ b/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
@@ -2,6 +2,7 @@ package com.iamkaf.liteminer.rendering;
 
 import com.iamkaf.amber.api.functions.v1.WorldFunctions;
 import com.iamkaf.liteminer.LiteminerClient;
+import com.iamkaf.liteminer.compat.IrisCompat;
 import com.mojang.blaze3d.PrimitiveTopology;
 import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.ColorTargetState;
@@ -90,6 +91,8 @@ public class BlockHighlightRenderer {
         RenderPipeline pipeline = RenderPipeline.builder(snippet)
                 .withLocation("pipeline/lines_translucent_no_depth")
                 .build();
+
+        IrisCompat.assignLinesPipeline(pipeline);
 
         RenderSetup setup = RenderSetup.builder(pipeline)
                 .setLayeringTransform(LayeringTransform.VIEW_OFFSET_Z_LAYERING)

--- a/common/src/main/java/com/iamkaf/liteminer/shapes/Walker.java
+++ b/common/src/main/java/com/iamkaf/liteminer/shapes/Walker.java
@@ -47,7 +47,8 @@ public interface Walker {
         if (TagHelper.isExcludedTool(tool)) {
             return false;
         }
-        return !Liteminer.CONFIG.requireCorrectToolEnabled.get() || (!tool.isEmpty() && (tool.isCorrectToolForDrops(state) || TagHelper.isIncludedTool(
-                tool)));
+        return !Liteminer.CONFIG.requireCorrectToolEnabled.get()
+                || !state.requiresCorrectToolForDrops()
+                || (!tool.isEmpty() && (tool.isCorrectToolForDrops(state) || TagHelper.isIncludedTool(tool)));
     }
 }

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -9,6 +9,11 @@ val minecraftVersion = multiloader.minecraftVersion()
 val catalog = multiloader.catalogFor()
 
 dependencies {
+    val irisConfiguration = if (multiloader.useUnobfuscatedMinecraft()) "compileOnly" else "modCompileOnly"
+    add(irisConfiguration, "maven.modrinth:iris:${multiloader.requiredProperty("dependencies.iris")}") {
+        isTransitive = false
+    }
+
     if (minecraftVersion != "26.2") {
         val configuration = if (multiloader.useUnobfuscatedMinecraft()) "implementation" else "modImplementation"
         add(configuration, multiloader.library(catalog, "forgeconfigapiport-fabric"))

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -9,6 +9,10 @@ val minecraftVersion = multiloader.minecraftVersion()
 val catalog = multiloader.catalogFor()
 
 dependencies {
+    compileOnly("maven.modrinth:iris:${multiloader.requiredProperty("dependencies.iris")}") {
+        isTransitive = false
+    }
+
     if (minecraftVersion != "26.2") {
         add("implementation", multiloader.library(catalog, "forgeconfigapiport-forge"))
     }

--- a/modstage.toml
+++ b/modstage.toml
@@ -24,8 +24,8 @@ mods = [
   "maven:com.iamkaf.liteminer:liteminer-fabric:3.1.2+1.21.11",
   "maven:net.fabricmc.fabric-api:fabric-api:0.141.3+1.21.11",
   "maven:fuzs.forgeconfigapiport:forgeconfigapiport-fabric:21.11.1",
-  "maven:com.iamkaf.amber:amber-fabric:11.1.1+1.21.11",
-  "maven:com.iamkaf.teakit:teakit-fabric:0.13.2+1.21.11",
+  "maven:com.iamkaf.amber:amber-fabric:11.2.0+1.21.11",
+  "maven:com.iamkaf.teakit:teakit-fabric:0.14.0+1.21.11",
 ]
 
 [[instance]]
@@ -37,8 +37,8 @@ sides = ["client", "server"]
 mods = [
   "maven:com.iamkaf.liteminer:liteminer-forge:3.1.2+1.21.11",
   "maven:fuzs.forgeconfigapiport:forgeconfigapiport-forge:21.11.1",
-  "maven:com.iamkaf.amber:amber-forge:11.1.1+1.21.11",
-  "maven:com.iamkaf.teakit:teakit-forge:0.13.2+1.21.11",
+  "maven:com.iamkaf.amber:amber-forge:11.2.0+1.21.11",
+  "maven:com.iamkaf.teakit:teakit-forge:0.14.0+1.21.11",
 ]
 
 [[instance]]
@@ -49,8 +49,8 @@ loader_version = "21.11.38-beta"
 sides = ["client", "server"]
 mods = [
   "maven:com.iamkaf.liteminer:liteminer-neoforge:3.1.2+1.21.11",
-  "maven:com.iamkaf.amber:amber-neoforge:11.1.1+1.21.11",
-  "maven:com.iamkaf.teakit:teakit-neoforge:0.13.2+1.21.11",
+  "maven:com.iamkaf.amber:amber-neoforge:11.2.0+1.21.11",
+  "maven:com.iamkaf.teakit:teakit-neoforge:0.14.0+1.21.11",
 ]
 
 [[instance]]
@@ -63,8 +63,8 @@ mods = [
   "maven:com.iamkaf.liteminer:liteminer-fabric:3.1.2+26.1",
   "maven:net.fabricmc.fabric-api:fabric-api:0.144.0+26.1",
   "maven:fuzs.forgeconfigapiport:forgeconfigapiport-fabric:26.1.0.1",
-  "maven:com.iamkaf.amber:amber-fabric:11.1.1+26.1",
-  "maven:com.iamkaf.teakit:teakit-fabric:0.13.2+26.1",
+  "maven:com.iamkaf.amber:amber-fabric:11.2.0+26.1",
+  "maven:com.iamkaf.teakit:teakit-fabric:0.14.0+26.1",
 ]
 
 [[instance]]
@@ -76,8 +76,8 @@ sides = ["client", "server"]
 mods = [
   "maven:com.iamkaf.liteminer:liteminer-forge:3.1.2+26.1",
   "maven:fuzs.forgeconfigapiport:forgeconfigapiport-forge:26.1.0.2",
-  "maven:com.iamkaf.amber:amber-forge:11.1.1+26.1",
-  "maven:com.iamkaf.teakit:teakit-forge:0.13.2+26.1",
+  "maven:com.iamkaf.amber:amber-forge:11.2.0+26.1",
+  "maven:com.iamkaf.teakit:teakit-forge:0.14.0+26.1",
 ]
 
 [[instance]]
@@ -88,8 +88,8 @@ loader_version = "26.1.0.1-beta"
 sides = ["client", "server"]
 mods = [
   "maven:com.iamkaf.liteminer:liteminer-neoforge:3.1.2+26.1",
-  "maven:com.iamkaf.amber:amber-neoforge:11.1.1+26.1",
-  "maven:com.iamkaf.teakit:teakit-neoforge:0.13.2+26.1",
+  "maven:com.iamkaf.amber:amber-neoforge:11.2.0+26.1",
+  "maven:com.iamkaf.teakit:teakit-neoforge:0.14.0+26.1",
 ]
 
 [[instance]]
@@ -102,8 +102,8 @@ mods = [
   "maven:com.iamkaf.liteminer:liteminer-fabric:3.1.2+26.1.1",
   "maven:net.fabricmc.fabric-api:fabric-api:0.145.4+26.1.1",
   "maven:fuzs.forgeconfigapiport:forgeconfigapiport-fabric:26.1.3",
-  "maven:com.iamkaf.amber:amber-fabric:11.1.1+26.1.1",
-  "maven:com.iamkaf.teakit:teakit-fabric:0.13.2+26.1.1",
+  "maven:com.iamkaf.amber:amber-fabric:11.2.0+26.1.1",
+  "maven:com.iamkaf.teakit:teakit-fabric:0.14.0+26.1.1",
 ]
 
 [[instance]]
@@ -115,8 +115,8 @@ sides = ["client", "server"]
 mods = [
   "maven:com.iamkaf.liteminer:liteminer-forge:3.1.2+26.1.1",
   "maven:fuzs.forgeconfigapiport:forgeconfigapiport-forge:26.1.3",
-  "maven:com.iamkaf.amber:amber-forge:11.1.1+26.1.1",
-  "maven:com.iamkaf.teakit:teakit-forge:0.13.2+26.1.1",
+  "maven:com.iamkaf.amber:amber-forge:11.2.0+26.1.1",
+  "maven:com.iamkaf.teakit:teakit-forge:0.14.0+26.1.1",
 ]
 
 [[instance]]
@@ -127,8 +127,8 @@ loader_version = "26.1.1.10-beta"
 sides = ["client", "server"]
 mods = [
   "maven:com.iamkaf.liteminer:liteminer-neoforge:3.1.2+26.1.1",
-  "maven:com.iamkaf.amber:amber-neoforge:11.1.1+26.1.1",
-  "maven:com.iamkaf.teakit:teakit-neoforge:0.13.2+26.1.1",
+  "maven:com.iamkaf.amber:amber-neoforge:11.2.0+26.1.1",
+  "maven:com.iamkaf.teakit:teakit-neoforge:0.14.0+26.1.1",
 ]
 
 [[instance]]
@@ -141,8 +141,8 @@ mods = [
   "maven:com.iamkaf.liteminer:liteminer-fabric:3.1.2+26.1.2",
   "maven:net.fabricmc.fabric-api:fabric-api:0.152.1+26.1.2",
   "maven:fuzs.forgeconfigapiport:forgeconfigapiport-fabric:26.1.3",
-  "maven:com.iamkaf.amber:amber-fabric:11.1.1+26.1.2",
-  "maven:com.iamkaf.teakit:teakit-fabric:0.13.2+26.1.2",
+  "maven:com.iamkaf.amber:amber-fabric:11.2.0+26.1.2",
+  "maven:com.iamkaf.teakit:teakit-fabric:0.14.0+26.1.2",
 ]
 
 [[instance]]
@@ -154,8 +154,8 @@ sides = ["client", "server"]
 mods = [
   "maven:com.iamkaf.liteminer:liteminer-forge:3.1.2+26.1.2",
   "maven:fuzs.forgeconfigapiport:forgeconfigapiport-forge:26.1.3",
-  "maven:com.iamkaf.amber:amber-forge:11.1.1+26.1.2",
-  "maven:com.iamkaf.teakit:teakit-forge:0.13.2+26.1.2",
+  "maven:com.iamkaf.amber:amber-forge:11.2.0+26.1.2",
+  "maven:com.iamkaf.teakit:teakit-forge:0.14.0+26.1.2",
 ]
 
 [[instance]]
@@ -166,6 +166,6 @@ loader_version = "26.1.2.76"
 sides = ["client", "server"]
 mods = [
   "maven:com.iamkaf.liteminer:liteminer-neoforge:3.1.2+26.1.2",
-  "maven:com.iamkaf.amber:amber-neoforge:11.1.1+26.1.2",
-  "maven:com.iamkaf.teakit:teakit-neoforge:0.13.2+26.1.2",
+  "maven:com.iamkaf.amber:amber-neoforge:11.2.0+26.1.2",
+  "maven:com.iamkaf.teakit:teakit-neoforge:0.14.0+26.1.2",
 ]

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -1,3 +1,13 @@
+import com.iamkaf.multiloader.support.MultiloaderProjectContext
+
 plugins {
     id("com.iamkaf.multiloader.neoforge")
+}
+
+val multiloader = MultiloaderProjectContext.of(project)
+
+dependencies {
+    compileOnly("maven.modrinth:iris:${multiloader.requiredProperty("dependencies.iris")}") {
+        isTransitive = false
+    }
 }

--- a/test/teakit/liteminer.test.ts
+++ b/test/teakit/liteminer.test.ts
@@ -12,6 +12,7 @@ describe.configure({
   readiness: [Readiness.World, Readiness.Player],
   capabilities: [
     Capability.ClientInput,
+    Capability.ClientScreen,
     Capability.ClientScreens,
     Capability.ClientScreenshot,
     Capability.PlayerInteractions,
@@ -23,6 +24,7 @@ describe.configure({
     Capability.WorldClear,
     Capability.WorldEntities,
     Capability.WorldFill,
+    Capability.WorldLoot,
     Capability.WorldSetBlock,
   ],
 });
@@ -75,6 +77,99 @@ describe("Liteminer vein mining", () => {
       await ctx.client.screenshot("liteminer-highlight-lines");
     } finally {
       await cleanup(ctx, area, { x: 12, y: 70, z: 0 }, 12);
+    }
+  });
+
+  test("keeps collected drops inside the mined block", {
+    target: { minecraft: "26.2", loader: "fabric" },
+  }, async (ctx) => {
+    const area = box({ x: 98, y: 69, z: 0 }, { x: 102, y: 72, z: 7 });
+    const origin = { x: 100, y: 70, z: 3 };
+    let ticksFrozen = false;
+    try {
+      await ctx.client.closeMenus();
+      await ctx.client.keyState(96, false);
+      await ctx.client.command("/liteminer shape set 0");
+      await ctx.player.reset({ gameMode: "survival", inventory: "clear" });
+      await ctx.player.teleport({ x: 100, y: 70, z: 0 });
+      await removeEntities(ctx, origin, 16, "minecraft:item");
+      await ctx.world.clear(area.min, area.max);
+      await ctx.world.fill({ x: 98, y: 69, z: 0 }, { x: 102, y: 69, z: 7 }, "minecraft:stone");
+      await ctx.player.give("minecraft:netherite_pickaxe");
+      await ctx.player.inventory().selectHotbar(0);
+      await ctx.commands.assert("/enchant @s minecraft:silk_touch 1");
+      await ctx.world.setBlock(origin, "minecraft:coal_ore");
+      await ctx.world.setBlock({ x: 100, y: 70, z: 4 }, "minecraft:deepslate_coal_ore");
+
+      await ctx.client.lookAt({ x: 100.5, y: 70.5, z: 3.5 });
+      await ctx.client.keyState(96, true);
+      await ctx.runtime.wait(1_200);
+      await ctx.player.mine(origin, { timeoutMs: 5_000 });
+      await ctx.client.keyState(96, false);
+      await ctx.commands.assert("/tick freeze");
+      ticksFrozen = true;
+      const drops = await ctx.loot
+        .near(origin, { item: "minecraft:deepslate_coal_ore", radius: 8 })
+        .waitForCountAtLeast(1, { timeout: 3_000 });
+      const dropPosition = drops[0]?.pos;
+      if (!dropPosition) throw new Error("The collected secondary drop had no reported position");
+      expect(dropPosition.x).toBeGreaterThanOrEqual(100.2);
+      expect(dropPosition.x).toBeLessThanOrEqual(100.8);
+      expect(dropPosition.z).toBeGreaterThanOrEqual(4.2);
+      expect(dropPosition.z).toBeLessThanOrEqual(4.8);
+      await ctx.commands.assert("/tick unfreeze");
+      ticksFrozen = false;
+      await waitForAir(ctx, [origin, { x: 100, y: 70, z: 4 }]);
+    } finally {
+      if (ticksFrozen) await ctx.commands.assert("/tick unfreeze");
+      await ctx.client.keyState(96, false);
+      await ctx.player.reset({ gameMode: "creative", inventory: "clear" });
+      await removeEntities(ctx, origin, 16, "minecraft:item");
+      await removeEntities(ctx, origin, 16, "minecraft:experience_orb");
+      await ctx.world.clear(area.min, area.max);
+    }
+  });
+
+  test("allows no-tool blocks when the correct-tool check is enabled", {
+    target: { minecraft: "26.2" },
+  }, async (ctx) => {
+    const area = box({ x: 108, y: 69, z: 0 }, { x: 114, y: 72, z: 6 });
+    let correctToolToggled = false;
+    try {
+      await toggleRequireCorrectTool(ctx);
+      correctToolToggled = true;
+      await ctx.client.command("/liteminer shape set 0");
+      await ctx.player.reset({ gameMode: "survival", inventory: "clear" });
+      await ctx.player.teleport({ x: 111, y: 70, z: 0 });
+      await ctx.world.clear(area.min, area.max);
+      await ctx.world.fill({ x: 108, y: 69, z: 0 }, { x: 114, y: 69, z: 6 }, "minecraft:dirt");
+
+      await ctx.player.give("minecraft:golden_pickaxe");
+      await ctx.player.inventory().selectHotbar(0);
+      await setBlocks(ctx, [
+        block(111, 70, 2, "minecraft:diamond_ore"),
+        block(111, 70, 3, "minecraft:diamond_ore"),
+      ]);
+      await holdVeinmineAndMine(ctx, { x: 111, y: 70, z: 2 }, { x: 111.5, y: 70.5, z: 2.5 });
+      await waitForAir(ctx, [{ x: 111, y: 70, z: 2 }]);
+      await assertBlock(ctx, { x: 111, y: 70, z: 3 }, "minecraft:diamond_ore");
+
+      await ctx.player.reset({ gameMode: "survival", inventory: "clear" });
+      await ctx.world.clear({ x: 108, y: 70, z: 0 }, area.max);
+      for (let z = 2; z <= 4; z += 1) {
+        await ctx.world.setBlock({ x: 111, y: 70, z }, "minecraft:short_grass");
+      }
+      await holdVeinmineAndMine(ctx, { x: 111, y: 70, z: 2 }, { x: 111.5, y: 70.25, z: 2.5 });
+      await waitForAir(ctx, [
+        { x: 111, y: 70, z: 2 },
+        { x: 111, y: 70, z: 3 },
+        { x: 111, y: 70, z: 4 },
+      ]);
+    } finally {
+      await ctx.client.keyState(96, false);
+      await ctx.player.reset({ gameMode: "creative", inventory: "clear" });
+      await ctx.world.clear(area.min, area.max);
+      if (correctToolToggled) await toggleRequireCorrectTool(ctx);
     }
   });
 
@@ -327,6 +422,27 @@ async function removeEntities(ctx: TeaKitTestContext, origin: BlockPos, radius: 
 async function setExperience(ctx: TeaKitTestContext, points: number) {
   await ctx.commands.assert("/xp set @s 0 levels");
   await ctx.commands.assert(`/xp set @s ${points} points`);
+}
+
+async function toggleRequireCorrectTool(ctx: TeaKitTestContext) {
+  await ctx.client.closeMenus();
+  await ctx.client.command("/liteminer config");
+  let screen = await ctx.client.waitForScreen("Liteminer Configuration", { timeoutMs: 10_000 });
+  screen = await scrollToConfigEntry(ctx, "Require Correct Tool");
+  await screen.lists("selection_list").entry({ label: "Require Correct Tool" }).activate();
+  await ctx.runtime.wait(300);
+  await ctx.client.closeMenus();
+  await ctx.runtime.wait(500);
+}
+
+async function scrollToConfigEntry(ctx: TeaKitTestContext, label: string) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    let screen = await ctx.client.screen();
+    if (screen.lists().entries().some((entry) => entry.label === label)) return screen;
+    screen = await screen.scroll({ vertical: -4 });
+    await ctx.runtime.wait(150);
+  }
+  throw new Error(`Timed out scrolling to Liteminer config entry: ${label}`);
 }
 
 async function holdVeinmineAndMine(ctx: TeaKitTestContext, target: BlockPos, lookTarget: Vec3) {

--- a/versions/1.21.11/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
+++ b/versions/1.21.11/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
@@ -2,6 +2,7 @@ package com.iamkaf.liteminer.rendering;
 
 import com.iamkaf.amber.api.functions.v1.WorldFunctions;
 import com.iamkaf.liteminer.LiteminerClient;
+import com.iamkaf.liteminer.compat.IrisCompat;
 import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.platform.DepthTestFunction;
@@ -13,6 +14,8 @@ import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.client.renderer.rendertype.LayeringTransform;
+import net.minecraft.client.renderer.rendertype.OutputTarget;
 import net.minecraft.client.renderer.rendertype.RenderSetup;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
@@ -79,6 +82,7 @@ public class BlockHighlightRenderer {
                 .withBlend(BlendFunction.TRANSLUCENT)
                 .withCull(false)
                 .withDepthTestFunction(DepthTestFunction.NO_DEPTH_TEST)
+                .withDepthWrite(false)
                 .withVertexFormat(DefaultVertexFormat.POSITION_COLOR_NORMAL_LINE_WIDTH, VertexFormat.Mode.LINES)
                 .buildSnippet();
 
@@ -86,8 +90,11 @@ public class BlockHighlightRenderer {
                 .withLocation("pipeline/lines_translucent_no_depth")
                 .build();
 
+        IrisCompat.assignLinesPipeline(pipeline);
+
         RenderSetup setup = RenderSetup.builder(pipeline)
-                .useLightmap()
+                .setLayeringTransform(LayeringTransform.VIEW_OFFSET_Z_LAYERING)
+                .setOutputTarget(OutputTarget.ITEM_ENTITY_TARGET)
                 .createRenderSetup();
 
         return RenderType.create("lines_translucent_no_depth_test", setup);

--- a/versions/1.21.11/gradle.properties
+++ b/versions/1.21.11/gradle.properties
@@ -1,8 +1,9 @@
-project.version=3.1.3+1.21.11
+project.version=3.1.4+1.21.11
 project.java=21
 project.build-java=21
 project.minecraft=1.21.11
 project.enabled-loaders=fabric,forge,neoforge
+dependencies.iris=1.10.7+1.21.11-fabric
 
 mod.minecraft-range=[1.21.11, 1.22)
 mod.fabric-range=>=1.21.11

--- a/versions/26.1.1/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
+++ b/versions/26.1.1/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
@@ -2,6 +2,7 @@ package com.iamkaf.liteminer.rendering;
 
 import com.iamkaf.amber.api.functions.v1.WorldFunctions;
 import com.iamkaf.liteminer.LiteminerClient;
+import com.iamkaf.liteminer.compat.IrisCompat;
 import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.ColorTargetState;
 import com.mojang.blaze3d.pipeline.DepthStencilState;
@@ -89,6 +90,8 @@ public class BlockHighlightRenderer {
         RenderPipeline pipeline = RenderPipeline.builder(snippet)
                 .withLocation("pipeline/lines_translucent_no_depth")
                 .build();
+
+        IrisCompat.assignLinesPipeline(pipeline);
 
         RenderSetup setup = RenderSetup.builder(pipeline)
                 .setLayeringTransform(LayeringTransform.VIEW_OFFSET_Z_LAYERING)

--- a/versions/26.1.1/gradle.properties
+++ b/versions/26.1.1/gradle.properties
@@ -1,8 +1,9 @@
-project.version=3.1.3+26.1.1
+project.version=3.1.4+26.1.1
 project.java=25
 project.build-java=25
 project.minecraft=26.1.1
 project.enabled-loaders=fabric,forge,neoforge
+dependencies.iris=1.11.3+26.1-fabric
 
 mod.minecraft-range=[26.1.1, 27)
 mod.fabric-range=>=26.1.1

--- a/versions/26.1.2/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
+++ b/versions/26.1.2/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
@@ -2,6 +2,7 @@ package com.iamkaf.liteminer.rendering;
 
 import com.iamkaf.amber.api.functions.v1.WorldFunctions;
 import com.iamkaf.liteminer.LiteminerClient;
+import com.iamkaf.liteminer.compat.IrisCompat;
 import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.ColorTargetState;
 import com.mojang.blaze3d.pipeline.DepthStencilState;
@@ -89,6 +90,8 @@ public class BlockHighlightRenderer {
         RenderPipeline pipeline = RenderPipeline.builder(snippet)
                 .withLocation("pipeline/lines_translucent_no_depth")
                 .build();
+
+        IrisCompat.assignLinesPipeline(pipeline);
 
         RenderSetup setup = RenderSetup.builder(pipeline)
                 .setLayeringTransform(LayeringTransform.VIEW_OFFSET_Z_LAYERING)

--- a/versions/26.1.2/gradle.properties
+++ b/versions/26.1.2/gradle.properties
@@ -1,8 +1,9 @@
-project.version=3.1.3+26.1.2
+project.version=3.1.4+26.1.2
 project.java=25
 project.build-java=25
 project.minecraft=26.1.2
 project.enabled-loaders=fabric,forge,neoforge
+dependencies.iris=1.11.3+26.1-fabric
 
 mod.minecraft-range=[26.1.2, 27)
 mod.fabric-range=>=26.1.2

--- a/versions/26.1/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
+++ b/versions/26.1/common/src/main/java/com/iamkaf/liteminer/rendering/BlockHighlightRenderer.java
@@ -2,6 +2,7 @@ package com.iamkaf.liteminer.rendering;
 
 import com.iamkaf.amber.api.functions.v1.WorldFunctions;
 import com.iamkaf.liteminer.LiteminerClient;
+import com.iamkaf.liteminer.compat.IrisCompat;
 import com.mojang.blaze3d.pipeline.BlendFunction;
 import com.mojang.blaze3d.pipeline.ColorTargetState;
 import com.mojang.blaze3d.pipeline.DepthStencilState;
@@ -89,6 +90,8 @@ public class BlockHighlightRenderer {
         RenderPipeline pipeline = RenderPipeline.builder(snippet)
                 .withLocation("pipeline/lines_translucent_no_depth")
                 .build();
+
+        IrisCompat.assignLinesPipeline(pipeline);
 
         RenderSetup setup = RenderSetup.builder(pipeline)
                 .setLayeringTransform(LayeringTransform.VIEW_OFFSET_Z_LAYERING)

--- a/versions/26.1/gradle.properties
+++ b/versions/26.1/gradle.properties
@@ -1,8 +1,9 @@
-project.version=3.1.3+26.1
+project.version=3.1.4+26.1
 project.java=25
 project.build-java=25
 project.minecraft=26.1
 project.enabled-loaders=fabric,forge,neoforge
+dependencies.iris=1.11.3+26.1-fabric
 
 mod.minecraft-range=[26.1, 27)
 mod.fabric-range=>=26.1

--- a/versions/26.2/gradle.properties
+++ b/versions/26.2/gradle.properties
@@ -1,8 +1,9 @@
-project.version=4.1.2+26.2
+project.version=4.1.3+26.2
 project.java=25
 project.build-java=25
 project.minecraft=26.2
 project.enabled-loaders=fabric,forge,neoforge
+dependencies.iris=1.11.2+26.2-fabric
 
 mod.minecraft-range=>=26.2
 mod.fabric-range=>=26.2


### PR DESCRIPTION
With Iris shader packs enabled, Liteminer's see-through selection lines disappeared. Two older mining bugs could also exclude blocks that do not require a tool and spawn collected drops against neighboring blocks, where they could rise toward the surface.

This assigns Liteminer's custom highlight pipeline to Iris's line program while keeping Iris optional, restores the intended no-depth render state on Minecraft 1.21.11, follows vanilla's harvestability rule for blocks that do not require tools, and uses Minecraft's normal block-drop placement for collected items.

This ships as Liteminer 3.1.4 for Minecraft 1.21.11 through 26.1.2, and 4.1.3 for Minecraft 26.2.

Fixes #50.
Fixes #65.
Fixes #69.
Fixes #74.